### PR TITLE
Fix chat message overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,14 +31,15 @@ header {
     text-align: center;
 }
 
- #chat-box {
-     flex-grow: 1;
-     overflow-y: auto;
-     padding: 10px;
-     display: flex;
-     flex-direction: column;
-     gap: 15px;
- }
+#chat-box {
+    flex-grow: 1;
+    overflow-y: auto;
+    padding: 10px;
+    padding-bottom: 140px; /* ensure space for fixed input and footer */
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
 
 .user-msg,
 .ai-msg {


### PR DESCRIPTION
## Summary
- add bottom padding to `#chat-box` so the fixed input form no longer covers messages

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6872824ca0cc83288da667e50d63b69f